### PR TITLE
Move the link back to the landing page to top left corner of nav bar

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,7 @@
-baseURL = "https://IntelPython.github.io/oneAPI-for-SciPy"
+baseURL = "/"
+title = "oneAPI for SciPy"
+
+
 
 # Language settings
 contentDir = "content/en"
@@ -7,10 +10,6 @@ defaultContentLanguageInSubdir = false
 # Useful when translating.
 enableMissingTranslationPlaceholders = true
 
-[[menu.main]]
-   name = "oneAPI for SciPy"   # should change this name, or rename poster/
-   weight = 1
-   url = "https://IntelPython.github.io/oneAPI-for-SciPy"
 
 enableRobotsTXT = true
 


### PR DESCRIPTION
Move the link to the landing page to the top left corner of the nav bar. Hopefully we now do not open a fresh page whenever one clicks on the link.